### PR TITLE
Fix pull direction register access

### DIFF
--- a/src/ext_io.c
+++ b/src/ext_io.c
@@ -228,7 +228,7 @@ uint8_t ext_io_get_pull_enable(void)
 
 uint8_t ext_io_get_pull_Down_up(void)
 {
-    uint8_t val = i2c_read_bytes(EXT_IC_ADDR, REG_PULL_ENABLE);
+    uint8_t val = i2c_read_bytes(EXT_IC_ADDR, REG_PULL_DOWN_UP);
     char state[16] = {0};
     for(uint8_t i = 0; i < 8; i++)
     {


### PR DESCRIPTION
## Summary
- fix ext_io pull up/down register read

## Testing
- `west build -b native_posix` *(fails: command not found)*
- `cmake -B build -S .` *(fails: Could not find package configuration file provided by "Zephyr")*

------
https://chatgpt.com/codex/tasks/task_e_683f8fc89c48832580092aa23e4d5ec9